### PR TITLE
Add the Kube Descheduler Operator

### DIFF
--- a/cluster-config/descheduler/base/descheduler-operator-group.yaml
+++ b/cluster-config/descheduler/base/descheduler-operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-kube-descheduler-operator
+  namespace: openshift-kube-descheduler-operator
+spec:
+  targetNamespaces:
+  - openshift-kube-descheduler-operator

--- a/cluster-config/descheduler/base/descheduler-operator-namespace.yaml
+++ b/cluster-config/descheduler/base/descheduler-operator-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: openshift-kube-descheduler-operator
+spec: {}

--- a/cluster-config/descheduler/base/descheduler-operator-profile.yaml
+++ b/cluster-config/descheduler/base/descheduler-operator-profile.yaml
@@ -1,0 +1,14 @@
+apiVersion: operator.openshift.io/v1beta1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  deschedulingIntervalSeconds: 3600
+  logLevel: Normal
+  managementState: Managed
+  operatorLogLevel: Normal
+  profiles:
+  - AffinityAndTaints       
+  - TopologyAndDuplicates   
+  - LifecycleAndUtilization 

--- a/cluster-config/descheduler/base/descheduler-operator-subscription.yaml
+++ b/cluster-config/descheduler/base/descheduler-operator-subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-kube-descheduler-operator
+  namespace: openshift-kube-descheduler-operator
+spec:
+  channel: "4.7"
+  installPlanApproval: Automatic
+  name: cluster-kube-descheduler-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: clusterkubedescheduleroperator.4.7.0-202105141603.p0

--- a/cluster-config/descheduler/base/kustomization.yaml
+++ b/cluster-config/descheduler/base/kustomization.yaml
@@ -1,0 +1,8 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+resources:
+    - descheduler-operator-namespace.yaml
+    - descheduler-operator-group.yaml
+    - descheduler-operator-subscription.yaml
+    - descheduler-operator-profile.yaml

--- a/clusters/lab/kustomization.yaml
+++ b/clusters/lab/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - ../../cluster-config/sealed-secrets-operator/overlays/lab
   - ../../cluster-config/oauth/overlays/htpasswd
   - ../../cluster-config/groups-roles-bindings/base
+  - ../../cluster-config/descheduler/base
   - ../../apps/cerberus/base
   - ../../apps/benchmark-operator/base


### PR DESCRIPTION
Installs a subscription and default instance of the Descheduler Operator [1]

[1] https://docs.openshift.com/container-platform/4.7/nodes/scheduling/nodes-descheduler.html